### PR TITLE
[#164678563] Site currency

### DIFF
--- a/app/admin/items.rb
+++ b/app/admin/items.rb
@@ -16,7 +16,7 @@ ActiveAdmin.register Item do
     end
     column :name
     column :price do |item|
-      number_to_currency(item.price)
+      content_tag(:span, item.price, class: 'js-price')
     end
     column :description
     column :created_at
@@ -34,8 +34,8 @@ ActiveAdmin.register Item do
         end
       end
       row :name
-      row :price do
-        number_to_currency(item.price)
+      row :price do |item|
+        content_tag(:span, item.price, class: 'js-price')
       end
       row :description
       row :created_at

--- a/app/javascript/packs/active_admin.js
+++ b/app/javascript/packs/active_admin.js
@@ -1,0 +1,3 @@
+import {formatPrice} from './format';
+
+addEventListener('DOMContentLoaded', formatPrice);

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -11,47 +11,53 @@ window.lm = {};
 window.lm.utils = require('not-jquery');
 window.lm.Map = require('map');
 
-
 import Rails from 'rails-ujs';
+import * as ActiveStorage from 'activestorage';
+import {formatPrice} from './format';
+
 Rails.start();
+ActiveStorage.start();
 
-
-import * as ActiveStorage from 'activestorage'
-ActiveStorage.start()
-
-addEventListener("direct-upload:initialize", event => {
-  const { target, detail } = event
-  const { id, file } = detail
-  target.insertAdjacentHTML("beforebegin", `
+addEventListener('direct-upload:initialize', event => {
+  const {target, detail} = event;
+  const {id, file} = detail;
+  target.insertAdjacentHTML(
+    'beforebegin',
+    `
     <div id="direct-upload-${id}" class="direct-upload direct-upload--pending">
       <div id="direct-upload-progress-${id}" class="direct-upload__progress" style="width: 0%"></div>
       <span class="direct-upload__filename">${file.name}</span>
     </div>
-  `)
-})
+  `,
+  );
+});
 
-addEventListener("direct-upload:start", event => {
-  const { id } = event.detail
-  const element = document.getElementById(`direct-upload-${id}`)
-  element.classList.remove("direct-upload--pending")
-})
+addEventListener('direct-upload:start', event => {
+  const {id} = event.detail;
+  const element = document.getElementById(`direct-upload-${id}`);
+  element.classList.remove('direct-upload--pending');
+});
 
-addEventListener("direct-upload:progress", event => {
-  const { id, progress } = event.detail
-  const progressElement = document.getElementById(`direct-upload-progress-${id}`)
-  progressElement.style.width = `${progress}%`
-})
+addEventListener('direct-upload:progress', event => {
+  const {id, progress} = event.detail;
+  const progressElement = document.getElementById(
+    `direct-upload-progress-${id}`,
+  );
+  progressElement.style.width = `${progress}%`;
+});
 
-addEventListener("direct-upload:error", event => {
-  event.preventDefault()
-  const { id, error } = event.detail
-  const element = document.getElementById(`direct-upload-${id}`)
-  element.classList.add("direct-upload--error")
-  element.setAttribute("title", error)
-})
+addEventListener('direct-upload:error', event => {
+  event.preventDefault();
+  const {id, error} = event.detail;
+  const element = document.getElementById(`direct-upload-${id}`);
+  element.classList.add('direct-upload--error');
+  element.setAttribute('title', error);
+});
 
-addEventListener("direct-upload:end", event => {
-  const { id } = event.detail
-  const element = document.getElementById(`direct-upload-${id}`)
-  element.classList.add("direct-upload--complete")
-})
+addEventListener('direct-upload:end', event => {
+  const {id} = event.detail;
+  const element = document.getElementById(`direct-upload-${id}`);
+  element.classList.add('direct-upload--complete');
+});
+
+addEventListener('DOMContentLoaded', formatPrice);

--- a/app/javascript/packs/format.js
+++ b/app/javascript/packs/format.js
@@ -1,0 +1,45 @@
+import Globalize from 'globalize';
+import likelySubtags from 'cldr-data/supplemental/likelySubtags.json';
+import currencyData from 'cldr-data/supplemental/currencyData.json';
+
+Globalize.load(likelySubtags);
+Globalize.load(currencyData);
+
+const locales = ['vi', 'en'];
+
+const load_locale = locale => {
+  Globalize.load(require(`cldr-data/main/${locale}/currencies.json`));
+  Globalize.load(require(`cldr-data/main/${locale}/numbers.json`));
+};
+
+locales.map(locale => load_locale(locale));
+
+console.log(decodeURIComponent(document.cookie));
+
+const getCookie = cname => {
+  const name = cname + '=';
+  const ca = document.cookie.split(';');
+  for (let i = 0; i < ca.length; i++) {
+    let c = ca[i];
+    while (c.charAt(0) == ' ') {
+      c = c.substring(1);
+    }
+    if (c.indexOf(name) == 0) {
+      return c.substring(name.length, c.length);
+    }
+  }
+  return null;
+};
+
+const formatterByCurrency = currency =>
+  Globalize(getCookie('locale') || 'en').currencyFormatter(currency);
+
+export const formatPrice = () => {
+  const elements = document.getElementsByClassName('js-price');
+  const currency = document.head.querySelector('[name~=site_currency][content]')
+    .content;
+  const formatter = formatterByCurrency(currency);
+  Array.from(elements).forEach(element => {
+    element.innerHTML = formatter(parseFloat(element.innerText));
+  });
+};

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -40,6 +40,10 @@ class Setting < ApplicationRecord
     }
   end
 
+  def self.site_currency
+    fetch 'site.currency', 'USD'
+  end
+
   def has_attachment?
     attachment.attached?
   end

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -21,7 +21,9 @@
 <% end %>
 
 <section class="item-info">
-  <span class="item-info__price"><%= number_to_currency(@item.price) %></span>
+  <span class="item-info__price js-price">
+    <%= @item.price %>
+  </span>
   <h1 class="item-info__name"><%= @item.name %></h1>
   <p class="item-info__description"><%= @item.description %></p>
 </section>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,6 +19,7 @@
 
       <meta name="description" content="<%= Setting.site_tagline %>" />
     <% end %>
+    <meta name="site_currency" content="<%= Setting.site_currency %>" />
 
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -304,3 +304,16 @@ ActiveAdmin.setup do |config|
   #
   # config.order_clause = MyOrderClause
 end
+
+module AdminPageLayoutOverride
+  def build_active_admin_head(*args)
+    super
+
+    within head do
+      text_node(tag(:meta, name: 'site_currency', content: Setting.site_currency))
+      text_node(javascript_pack_tag('active_admin'))
+    end
+  end
+end
+
+ActiveAdmin::Views::Pages::Base.send :prepend, AdminPageLayoutOverride

--- a/config/webpack/custom.js
+++ b/config/webpack/custom.js
@@ -1,0 +1,8 @@
+module.exports = {
+  resolve: {
+    alias: {
+      cldr$: 'cldrjs',
+      cldr: 'cldrjs/dist/cldr',
+    },
+  },
+};

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,3 +1,6 @@
-const { environment } = require('@rails/webpacker')
+const {environment} = require('@rails/webpacker');
+const customConfig = require('./custom');
 
-module.exports = environment
+environment.config.merge(customConfig);
+
+module.exports = environment;

--- a/package.json
+++ b/package.json
@@ -3,10 +3,12 @@
   "private": true,
   "dependencies": {
     "@rails/webpacker": "3.5",
-    "rails-ujs":     "^5.2.2",
     "activestorage": "^5.2.2",
     "babel-preset-react": "^6.24.1",
+    "cldr-data": "^34.0.0",
+    "globalize": "^1.4.2",
     "prop-types": "^15.6.2",
+    "rails-ujs": "^5.2.2",
     "react": "^16.6.3",
     "react-dom": "^16.6.3"
   },

--- a/spec/features/currency_spec.rb
+++ b/spec/features/currency_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+describe 'Currency Format' do
+  let(:item) { FactoryBot.create(:item, price: 100) }
+  let(:location) { item.location }
+
+  include_examples 'admin login'
+
+  it "let user/admin see currency format in item page/admin page" do
+    item_path = location_item_path(location_id: location.id, id: item.id)
+    visit item_path
+    expect(page.current_path).to include(item_path)
+    expect(page).to have_content "$100.00"
+
+    visit admin_items_path
+    expect(page.current_path).to include(admin_items_path)
+    expect(page).to have_content "$100.00"
+
+    item_path = location_item_path(location_id: location.id, id: item.id, locale: 'vi')
+    visit item_path
+    expect(page).to have_content item.name
+    expect(page).to have_content "100,00 US$"
+  end
+end
+

--- a/spec/views/items/show.html.erb_spec.rb
+++ b/spec/views/items/show.html.erb_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe "items/show" do
-  
+
   let(:location)  { FactoryBot.create(:location) }
   let(:item)      { FactoryBot.create(:item, location: location ) }
 
@@ -16,7 +16,6 @@ describe "items/show" do
     render
 
     expect(rendered).to include(item.name)
-    expect(rendered).to include(number_to_currency(item.price))
     expect(rendered).to include(item.description)
   end
 end

--- a/yarn.lock
+++ b/yarn.lock
@@ -70,12 +70,17 @@ activestorage@^5.2.2:
   dependencies:
     spark-md5 "^3.0.0"
 
+adm-zip@0.4.11:
+  version "0.4.11"
+  resolved "https://registry.yarnpkg.com/adm-zip/-/adm-zip-0.4.11.tgz#2aa54c84c4b01a9d0fb89bb11982a51f13e3d62a"
+  integrity sha512-L8vcjDTCOIJk7wFvmlEUN7AsSb8T+2JrdP7KINBjzr24TJ5Mwj590sLu3BC7zNZowvJWa/JtPmD8eJCzdtDWjA==
+
 ajv-keywords@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.2.0.tgz#e86b819c602cf8821ad637413698f1dec021847a"
   integrity sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo=
 
-ajv@^5.0.0:
+ajv@^5.0.0, ajv@^5.1.0:
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
   integrity sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=
@@ -330,7 +335,7 @@ aws-sign2@~0.7.0:
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
   integrity sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=
 
-aws4@^1.8.0:
+aws4@^1.6.0, aws4@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
@@ -1415,6 +1420,32 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
+cldr-data-downloader@0.3.x:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/cldr-data-downloader/-/cldr-data-downloader-0.3.5.tgz#f5445cb9d222bf7fa8426c62e0ae9d7d4897b243"
+  integrity sha512-uyIMa1K98DAp/PE7dYpq2COIrkWn681Atjng1GgEzeJzYb1jANtugtp9wre6+voE+qzVC8jtWv6E/xZ1GTJdlw==
+  dependencies:
+    adm-zip "0.4.11"
+    mkdirp "0.5.0"
+    nopt "3.0.x"
+    progress "1.1.8"
+    q "1.0.1"
+    request "~2.87.0"
+    request-progress "0.3.1"
+
+cldr-data@^34.0.0:
+  version "34.0.0"
+  resolved "https://registry.yarnpkg.com/cldr-data/-/cldr-data-34.0.0.tgz#728f03a423bbc311550600116266554772d736b5"
+  integrity sha512-gh1P6ODImIi8F+p+XaGc9mV9Hgyd5rZSdvX1pfKvFPbaKLRZbKfmpr47NeV3oQDD2llMnSwXUUNnJo3aVnxu8w==
+  dependencies:
+    cldr-data-downloader "0.3.x"
+    glob "5.x.x"
+
+cldrjs@^0.5.0:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/cldrjs/-/cldrjs-0.5.1.tgz#b5dc4beae02555634b04b94deb8e22e13ff10319"
+  integrity sha512-xyiP8uAm8K1IhmpDndZLraloW1yqu0L+HYdQ7O1aGPxx9Cr+BMnPANlNhSt++UKfxytL2hd2NPXgTjiy7k43Ew==
+
 cliui@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-2.1.0.tgz#4b475760ff80264c762c3a1719032e91c7fea0d1"
@@ -1544,7 +1575,7 @@ colors@~1.1.2:
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63"
   integrity sha1-FopHAXVran9RoSzgyXv6KMCE7WM=
 
-combined-stream@^1.0.6, combined-stream@~1.0.6:
+combined-stream@^1.0.6, combined-stream@~1.0.5, combined-stream@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.7.tgz#2d1d24317afb8abe95d6d2c0b07b57813539d828"
   integrity sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==
@@ -2397,7 +2428,7 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
-extend@~3.0.2:
+extend@~3.0.1, extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
@@ -2597,7 +2628,7 @@ forever-agent@~0.6.1:
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
 
-form-data@~2.3.2:
+form-data@~2.3.1, form-data@~2.3.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"
   integrity sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==
@@ -2758,6 +2789,17 @@ glob-parent@^3.1.0:
     is-glob "^3.1.0"
     path-dirname "^1.0.0"
 
+glob@5.x.x:
+  version "5.0.15"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-5.0.15.tgz#1bc936b9e02f4a603fcc222ecf7633d30b8b93b1"
+  integrity sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=
+  dependencies:
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "2 || 3"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
 glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.2, glob@~7.1.1:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
@@ -2769,6 +2811,13 @@ glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.2, glob@~7.1.1:
     minimatch "^3.0.4"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
+
+globalize@^1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/globalize/-/globalize-1.4.2.tgz#3ff354c7ced0bbfab4cf7896d8cbb6f4c0fc37f5"
+  integrity sha512-IfKeYI5mAITBmT5EnH8kSQB5uGson4Fkj2XtTpyEbIS7IHNfLHoeTyLJ6tfjiKC6cJXng3IhVurDk5C7ORqFhQ==
+  dependencies:
+    cldrjs "^0.5.0"
 
 globals@^9.18.0:
   version "9.18.0"
@@ -2809,6 +2858,14 @@ har-schema@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
   integrity sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=
+
+har-validator@~5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.0.3.tgz#ba402c266194f15956ef15e0fcf242993f6a7dfd"
+  integrity sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=
+  dependencies:
+    ajv "^5.1.0"
+    har-schema "^2.0.0"
 
 har-validator@~5.1.0:
   version "5.1.3"
@@ -3927,7 +3984,7 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
   integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
 
-minimatch@^3.0.4, minimatch@~3.0.2:
+"minimatch@2 || 3", minimatch@^3.0.4, minimatch@~3.0.2:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
@@ -3990,6 +4047,13 @@ mixin-object@^2.0.1:
   dependencies:
     for-in "^0.1.3"
     is-extendable "^0.1.1"
+
+mkdirp@0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.0.tgz#1d73076a6df986cd9344e15e71fcc05a4c9abf12"
+  integrity sha1-HXMHam35hs2TROFecfzAWkyavxI=
+  dependencies:
+    minimist "0.0.8"
 
 mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   version "0.5.1"
@@ -4172,7 +4236,7 @@ node-sass@^4.9.2:
     stdout-stream "^1.4.0"
     "true-case-path" "^1.0.2"
 
-"nopt@2 || 3":
+"nopt@2 || 3", nopt@3.0.x:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"
   integrity sha1-xkZdvwirzU2zWTF/eaxopkayj/k=
@@ -4258,6 +4322,11 @@ number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
   integrity sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=
+
+oauth-sign@~0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
+  integrity sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=
 
 oauth-sign@~0.9.0:
   version "0.9.0"
@@ -5225,6 +5294,11 @@ process@^0.11.10:
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
 
+progress@1.1.8:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
+  integrity sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=
+
 promise-inflight@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
@@ -5305,12 +5379,17 @@ punycode@^2.1.0:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
+q@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/q/-/q-1.0.1.tgz#11872aeedee89268110b10a718448ffb10112a14"
+  integrity sha1-EYcq7t7okmgRCxCnGESP+xARKhQ=
+
 q@^1.1.2:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
   integrity sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=
 
-qs@6.5.2, qs@~6.5.2:
+qs@6.5.2, qs@~6.5.1, qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
@@ -5598,6 +5677,13 @@ repeating@^2.0.0:
   dependencies:
     is-finite "^1.0.0"
 
+request-progress@0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/request-progress/-/request-progress-0.3.1.tgz#0721c105d8a96ac6b2ce8b2c89ae2d5ecfcf6b3a"
+  integrity sha1-ByHBBdipasayzossia4tXs/Pazo=
+  dependencies:
+    throttleit "~0.0.2"
+
 request@^2.87.0, request@^2.88.0:
   version "2.88.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
@@ -5623,6 +5709,32 @@ request@^2.87.0, request@^2.88.0:
     tough-cookie "~2.4.3"
     tunnel-agent "^0.6.0"
     uuid "^3.3.2"
+
+request@~2.87.0:
+  version "2.87.0"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.87.0.tgz#32f00235cd08d482b4d0d68db93a829c0ed5756e"
+  integrity sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==
+  dependencies:
+    aws-sign2 "~0.7.0"
+    aws4 "^1.6.0"
+    caseless "~0.12.0"
+    combined-stream "~1.0.5"
+    extend "~3.0.1"
+    forever-agent "~0.6.1"
+    form-data "~2.3.1"
+    har-validator "~5.0.3"
+    http-signature "~1.2.0"
+    is-typedarray "~1.0.0"
+    isstream "~0.1.2"
+    json-stringify-safe "~5.0.1"
+    mime-types "~2.1.17"
+    oauth-sign "~0.8.2"
+    performance-now "^2.1.0"
+    qs "~6.5.1"
+    safe-buffer "^5.1.1"
+    tough-cookie "~2.3.3"
+    tunnel-agent "^0.6.0"
+    uuid "^3.1.0"
 
 require-directory@^2.1.1:
   version "2.1.1"
@@ -6338,6 +6450,11 @@ tar@^4:
     safe-buffer "^5.1.2"
     yallist "^3.0.2"
 
+throttleit@~0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/throttleit/-/throttleit-0.0.2.tgz#cfedf88e60c00dd9697b61fdd2a8343a9b680eaf"
+  integrity sha1-z+34jmDADdlpe2H90qg0OptoDq8=
+
 through2@^2.0.0:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.5.tgz#01c1e39eb31d07cb7d03a96a70823260b23132cd"
@@ -6397,6 +6514,13 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     extend-shallow "^3.0.2"
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
+
+tough-cookie@~2.3.3:
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.4.tgz#ec60cee38ac675063ffc97a5c18970578ee83655"
+  integrity sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==
+  dependencies:
+    punycode "^1.4.1"
 
 tough-cookie@~2.4.3:
   version "2.4.3"
@@ -6616,7 +6740,7 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
 
-uuid@^3.0.1, uuid@^3.3.2:
+uuid@^3.0.1, uuid@^3.1.0, uuid@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==


### PR DESCRIPTION
1. I have to load cldr-data manually, can not load `entireSuplemental` -> leads to V8 Engine out of heap mem.
2. GlobalizeJs primarily supports for AMD, not webpack -> I need to add a custom alias webpack config to load `cldrjs` instead of `cldr`
3. ActiveAdmin currently doesn't support webpack assets (only asset pipeline, which is not being used in our base) -> I have to do some trick to load webpack assets in ActiveAdmin setup
4. Change USD to VND works well but it raises a concern about incorrect price, for example: when price is 100, the USD will be: `$100.00` and the VND will be `đ100`. Presentation is correct but not the price itself.
5. We are using erb template to render view which is server side rendering (also in active admin), but formating currency in client side -> I have to do some trick on this.
6. get locale from cookie is simple so I add that logic into this PR.