### PR TITLE
[#167668035] improper phone number normalization strips the "+"

### DIFF
--- a/app/helpers/chats_helper.rb
+++ b/app/helpers/chats_helper.rb
@@ -10,7 +10,7 @@ module ChatsHelper
     )
   end
 
-  def chat_link(url:, label_text:, asset: )
+  def chat_link(url:, label_text:, asset:)
     tag.li class: 'chat-links__link' do
       link_to(url, target: '_blank') do
         concat icon(asset, class: 'chat-links__icon m--clickable')
@@ -20,11 +20,11 @@ module ChatsHelper
   end
 
   def normalize_phone_number(phone_number)
-    phone_number.gsub(/\-|\+/, '').sub(/^0*/, '')
+    phone_number.gsub(/\D/, '').sub(/^0*/, '')
   end
 
   def native_chat_url messenger, id, regarding: nil
-    normalized = normalize_phone_number(id)
+    normalized     = normalize_phone_number(id)
     text_parameter = ""
 
     if regarding.present?
@@ -43,7 +43,7 @@ module ChatsHelper
   end
 
   def call_url(phone_number)
-    "tel:#{normalize_phone_number(phone_number)}"
+    "tel:#{phone_number}"
   end
 
   def regarding_info(name, url)

--- a/spec/helpers/chats_helper_spec.rb
+++ b/spec/helpers/chats_helper_spec.rb
@@ -3,22 +3,37 @@ require 'rails_helper'
 describe ChatsHelper do
 
   describe "#native_chat_url" do
+    let(:urls) {
+      {
+        'facebook' => 'https://m.me/',
+        'whatsapp' => 'https://wa.me/',
+        'zalo' => 'https://zalo.me/'
+      }
+    }
     it "returns correct url" do
-      expect(helper.native_chat_url('facebook', '123')).to eq 'https://m.me/123'
-      expect(helper.native_chat_url('whatsapp', '123')).to eq 'https://wa.me/123'
-      expect(helper.native_chat_url('zalo', '123')).to     eq 'https://zalo.me/123'
+      expected = '123'
+
+      urls.each do |k,v|
+        expect(helper.native_chat_url(k, expected)).to eq "#{v}#{expected}"
+      end
     end
 
-    it "strips any zeroes, brackets or dashes" do
-      expect(helper.native_chat_url('whatsapp', '+00123')).to eq 'https://wa.me/123'
-      expect(helper.native_chat_url('whatsapp', '+62123')).to eq 'https://wa.me/62123'
-      expect(helper.native_chat_url('whatsapp', '+621-2-3')).to eq 'https://wa.me/62123'
+    it "strips any non-number characters" do
+      data = [%w(+00123 123), %w(+62123 62123),
+              %w(+621-2-3 62123), %w(+62\ 1\ 2\ 3 62123)]
+      urls.each do |k, v|
+        data.each do |item|
+          input, output = item
+          expect(helper.native_chat_url(k, input)).to eq "#{v}#{output}"
+        end
+      end
     end
 
-    it "adds the regarding text if supplied" do 
-      expect(helper.native_chat_url('whatsapp', '+00123', regarding: 'foo bar')).to include('text=')
-      expect(helper.native_chat_url('whatsapp', '+00123', regarding: 'foo bar')).to include('foo%20bar')
+    context 'whatsapp' do
+      it "adds the regarding text if supplied" do
+        expect(helper.native_chat_url('whatsapp', '+00123', regarding: 'foo bar')).to include('text=')
+        expect(helper.native_chat_url('whatsapp', '+00123', regarding: 'foo bar')).to include('foo%20bar')
+      end
     end
   end
-
 end


### PR DESCRIPTION
from a user's phone number, making them 
uncontactable.

[https://www.pivotaltracker.com/story/show/167668035]